### PR TITLE
@everyone assignments.

### DIFF
--- a/public/markdown/permissions.md
+++ b/public/markdown/permissions.md
@@ -8,11 +8,11 @@ FredBoat uses 4 different ranks each with different permissions.
 
 * 2: DJ
 
-*Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc*
+*Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc. By default, @everyone is set to this permission.*
 
 * 1: User
 
-*Can add tracks to the queue and can only skip their own tracks*
+*Can add tracks to the queue and can only skip their own tracks. Remove @everyone from the DJ permission to assign them as a User.*
 
 * 0: Base
 


### PR DESCRIPTION
By far the most frequently asked questions we get about the permissions system is because DJ is automatically assigned to everyone. Hopefully, the above additions will help reduce the amount of questions regarding the @everyone assignment because, in general, most of these people just want their users to be set to user.