### PR TITLE
Permission Ranks Table

### DIFF
--- a/public/markdown/permissions.md
+++ b/public/markdown/permissions.md
@@ -2,28 +2,19 @@
 When developing the permission system it was decided we wanted a simple permission system that could easily be configured.
 FredBoat uses 4 different ranks each with different permissions.
 
-* 3: Admin
-
-*Can change [FredBoat configuration](https://fredboat.com/docs/configuration) and edit permissions*
-
-* 2: DJ
-
-*Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc. By default, @everyone is set to this permission.*
-
-* 1: User
-
-*Can add tracks to the queue and can only skip their own tracks. Remove @everyone from the DJ permission to assign them as a User.*
-
-* 0: Base
-
-*Given to everyone without higher ranks. Cannot modify the queue or player, but can still use commands like ;;list, ;;np, etc*
+| Ranks                     | Permission Description                  |
+|------------------------------|-----------------------------------------------------------------------|
+| 3:Admin                     | Can change [FredBoat configuration](https://fredboat.com/docs/configuration) and edit permissions                  |
+| 2:DJ                      | Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc. **By default, `@everyone` is set to this permission.**                  |
+| 1:User                      | Can add tracks to the queue and can only skip their own tracks. Remove `@everyone` from the DJ permission to assign them as a User.                  |
+| 0:Base                     | Given to everyone without higher ranks. Cannot modify the queue or player, but can still use commands like ;;list, ;;np, et cetera                  |
 
 ## Special notes
 * Users with the Discord "Administrator" permission and owners implicitly have all perms.
 * Permissions are specific for a server, never a channel.
 * Higher ranks also have lower rank permissions.
 * Permissions can be granted to users or roles. This includes the `@everyone` role.
-* By default, everyone has the DJ and User roles, but this can be restricted.
+* By default, everyone has the DJ and User roles. Use the below commands to delete the `@everyone` role from the DJ list and make them Users.
 
 ## The permission commands
 These are the command available:
@@ -42,7 +33,7 @@ These are the command available:
 
 The name of the command specifies which rank you are modifying or listing. 
 
-These commands are restricted to users with the ADMIN permissions, apart from the `list` subcommand. The `add` subcommand can be used to add users or roles.
+These commands are restricted to users with the ADMIN permissions, apart from the `list` subcommand. The `add` subcommand can be used to add usernames or roles to a permission rank.
 
 ![add command](https://fred.moe/3tO.png)
 
@@ -55,4 +46,4 @@ You do not need to specify the full name of a user or role to add/remove them. F
 ![search](https://fred.moe/GRe.png)
 
 ## A note about selfhosting
-The owner of the bot application the bot is running on is automatically given the `BOT_OWNER` permission. Admins specified in `configuration.yml` are granted the `BOT_ADMIN` role. These ranks allows nearly complete control of the bot for things like restarting the bot, in addition to `ADMIN` permissions in all servers. 
+The owner of the bot application the bot is running on is automatically given the `BOT_OWNER` permission. Admins specified in `configuration.yml` are granted the `BOT_ADMIN` role. These ranks allow nearly complete control of the bot for things like restarting the bot, in addition to `ADMIN` permissions in all servers. 

--- a/public/markdown/permissions.md
+++ b/public/markdown/permissions.md
@@ -5,8 +5,8 @@ FredBoat uses 4 different ranks each with different permissions.
 | Ranks                     | Permission Description                  |
 |------------------------------|-----------------------------------------------------------------------|
 | 3:Admin                     | Can change [FredBoat configuration](https://fredboat.com/docs/configuration) and edit permissions                  |
-| 2:DJ                      | Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc. **By default, @everyone is set to this permission.**                  |
-| 1:User                      | Can add tracks to the queue and can only skip their own tracks. Remove @everyone from the DJ permission to assign them as a User.                  |
+| 2:DJ                      | Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc. **By default, ``@everyone`` is set to this permission.**                  |
+| 1:User                      | Can add tracks to the queue and can only skip their own tracks. Remove ``@everyone`` from the DJ permission to assign them as a User.                  |
 | 0:Base                     | Given to everyone without higher ranks. Cannot modify the queue or player, but can still use commands like ;;list, ;;np, et cetera                  |
 
 ## Special notes

--- a/public/markdown/permissions.md
+++ b/public/markdown/permissions.md
@@ -5,8 +5,8 @@ FredBoat uses 4 different ranks each with different permissions.
 | Ranks                     | Permission Description                  |
 |------------------------------|-----------------------------------------------------------------------|
 | 3:Admin                     | Can change [FredBoat configuration](https://fredboat.com/docs/configuration) and edit permissions                  |
-| 2:DJ                      | Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc. **By default, `@everyone` is set to this permission.**                  |
-| 1:User                      | Can add tracks to the queue and can only skip their own tracks. Remove `@everyone` from the DJ permission to assign them as a User.                  |
+| 2:DJ                      | Can skip, can pause/unpause, can change repeat mode, can change shuffle mode, etc. **By default, @everyone is set to this permission.**                  |
+| 1:User                      | Can add tracks to the queue and can only skip their own tracks. Remove @everyone from the DJ permission to assign them as a User.                  |
 | 0:Base                     | Given to everyone without higher ranks. Cannot modify the queue or player, but can still use commands like ;;list, ;;np, et cetera                  |
 
 ## Special notes

--- a/src/docs/css/Markdown.sass
+++ b/src/docs/css/Markdown.sass
@@ -14,7 +14,7 @@
         margin-bottom: -8px
     code
         background-color: #272524
-        padding: 8px
+        padding: 2px
         word-wrap: break-word
     pre > code
         display: block


### PR DESCRIPTION
I have noticed people have been frequently confused by the permissions system the way it is laid out as the rank description is under the actual rank. So, I formatted them to be side by side in a table so it may be more easily understood. Included a quick refinement of the notes bullet including the default dj rank, and a quick grammar check at the end.